### PR TITLE
Docs: command output, path typo and petclinic main remote branch

### DIFF
--- a/03.OpenShift-Pipelines/README.adoc
+++ b/03.OpenShift-Pipelines/README.adoc
@@ -267,7 +267,7 @@ spec:
 ```
 
 ```shell
-oc apply -f pipelines/04-say-things-pipelinerun.yaml
+oc apply -f pipeline/04-say-things-pipelinerun.yaml
 ```
 
 OpenShift has a dashboard to check and review the current status of the `Pipeline` and `PipelineRun` from

--- a/03.OpenShift-Pipelines/README.adoc
+++ b/03.OpenShift-Pipelines/README.adoc
@@ -123,7 +123,7 @@ the parameter:
   --showlog
 TaskRun started: hello-params-task-run-jqfbs
 Waiting for logs to be available...
-[say-hello] My name
+[say-hello] Hello My name
 ```
 
 ### Multiple Stepped Task

--- a/03.OpenShift-Pipelines/README.adoc
+++ b/03.OpenShift-Pipelines/README.adoc
@@ -485,7 +485,7 @@ parameters declared in the pipeline:
 ```shell
 tkn pipeline start count-workspace-pipeline \
     --param GIT_URL=https://github.com/spring-projects/spring-petclinic.git \
-    --param GIT_REVISION=master \
+    --param GIT_REVISION=main \
     --workspace name=workspace,claimName=workspace-pvc \
     --showlog
 ```


### PR DESCRIPTION
Solving some typos.
- Example output
- Referenced file path to be applied
- petclinic git branch